### PR TITLE
Changes to Heroku Buildpack API

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,5 @@ Further Information
 [Buildpacks: Heroku for Everything](http://blog.heroku.com/archives/2012/7/17/buildpacks/)
 
 [Grunt: a task-based command line build tool for JavaScript projects](http://gruntjs.com/)
+
+(nop)


### PR DESCRIPTION
Hey Stephan, I'm sending this PR because I can't find other ways to contact you. Feel free to disregard the PR.

We are making some changes to the way app config is available during builds and those changes are likely to affect users of your buildpack. This is because many users of your buildpack have [user-env-compile](https://devcenter.heroku.com/articles/labs-user-env-compile) enabled. `user-env-compile`makes the app config available during builds.

Upstream buildpacks have already been modified to account the changes and you might be able to simply backport those changes:
- https://github.com/mbuchetics/heroku-buildpack-nodejs-grunt
- https://github.com/heroku/heroku-buildpack-nodejs

The change means that we will start injecting the application config into builds on all apps, not just ones with the `user-env-compile` [labs flag](https://devcenter.heroku.com/articles/labs-user-env-compile) set. The user-env-compile labs feature will eventually be deprecated.

With this change to the Buildpack API, app config is available to the buildpack’s `bin/compile` script as files in a directory. The location of the directory is passed as the third argument to the `bin/compile` script

``` term
bin/compile BUILD_DIR CACHE_DIR ENV_DIR
```

You can read more about how the `compile` script will work in this [staging-version of the Buildpack API documentation](https://devcenter.heroku.com/articles/buildpack-api-staging?preview=1#bin-compile). The article also has sample Bash code demonstrating how to read and export the contents of the `ENV_DIR` directory.

To get early access and test changes to your buildpack on a real app, you can enable the `buildpack-env-arg` labs feature by running:

``` term
$ heroku labs:enable buildpack-env-arg --app example-app
```

We expect to start passing the new argument to buildpacks on in the coming weeks. During the rollout, you should check for existence of the third argument to the `bin/compile` script. We will migrate apps with `user-env-compile` when relevant buildpacks are updated to support the `END_DIR` argument. Eventually, support for `user-env-compile` will be removed and all builds will be passed the ENV_DIR argument.

Once the rollout has completed, we recommend updating any buildpack documentation that mentions `user-env-compile`. Users will no longer have to add user-env-compile to use the application runtime environment during builds.

If we don’t hear back from you, we will try to contact affected users currently using `user-env-compile` to make them aware that builds with your buildpack may stop working and suggest workarounds.

Feel free to get in touch if you have any questions about this process.
