### PR TITLE
ruby version fix

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -148,7 +148,7 @@ fi
 
 # install compass
 status "Installing Compass"
-export GEM_HOME=$build_dir/.gem/ruby/1.9.1
+export GEM_HOME=$build_dir/.gem/ruby/2.3.0
 PATH="$GEM_HOME/bin:$PATH"
 if test -d $cache_dir/ruby/.gem; then
   status "Restoring ruby gems directory from cache"


### PR DESCRIPTION
PR to fix this warning when `grunt-contrib-sass` is run on heroku node server.
`Warning: You need to have Ruby and Sass installed and in your PATH for this task to work`
